### PR TITLE
0.12 Update SETUP_AddPlatformAndMagazineToWeapons.lua

### DIFF
--- a/Code/SETUP_AddPlatformAndMagazineToWeapons.lua
+++ b/Code/SETUP_AddPlatformAndMagazineToWeapons.lua
@@ -55,13 +55,15 @@ function OnMsg.ClassesGenerate()
 	-- AppendClass.FirearmBase = {
 	-- 	magazine = false
 	-- }
+end
 
+function OnMsg.ClassesPreprocess()
 	REV_SetupWeapon(HiPower, "HiPower", "BHPMagazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(Bereta92, "Beretta", "BerettaMagazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(Glock18, "Glock", "GlockMagazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(DesertEagle, "DesertEagle", "DesertEagleMagazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(UZI, "UZI", "UZIMagazine", "MagNormal", {"MagLarge", "MagNormal"})
-	REV_SetupWeapon(LionRoar, "UZI", "UZIMagazine", "MagLarge", {"MagLarge", "MagNormal"})
+	-- REV_SetupWeapon(LionRoar, "UZI", "UZIMagazine", "MagLarge", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(MP5, "MP5", "MP5Magazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(MP5K, "MP5", "MP5Magazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(MP40, "MP40", "MP40Magazine", "MagNormal", {"MagLarge", "MagNormal"})
@@ -78,7 +80,7 @@ function OnMsg.ClassesGenerate()
 	REV_SetupWeapon(Galil_FlagHill, "Galil", "GalilMagazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(G36, "G36", "G36MagazineLarge", "MagLarge", {"MagLarger", "MagLarge"})
 	REV_SetupWeapon(M14SAW, "M14", "M14Magazine", "MagNormal", {"MagLarge", "MagNormal"})
-	REV_SetupWeapon(GoldenGun, "M14", "M14Magazine", "MagNormal", {"MagLarge", "MagNormal"})
+	-- REV_SetupWeapon(GoldenGun, "M14", "M14Magazine", "MagNormal", {"MagLarge", "MagNormal"})
 	-- REV_SetupWeapon(M24Sniper, "M14", "M14Magazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(PSG1, "HKG3", "HKG3Magazine", "MagNormal", {"MagLarge", "MagNormal"})
 	REV_SetupWeapon(DragunovSVD, "SVD", "SVDMagazine", "MagNormal", {"MagNormal"})

--- a/metadata.lua
+++ b/metadata.lua
@@ -2,11 +2,11 @@ return PlaceObj('ModDef', {
 	'title', "Revised Mags II",
 	'description', "This is a reworked rerelease of Ablomis' Revised Mags mod. \n\nThis mod adds magazines for weapons to the game. \n\nIt is recommended that you use the Revised Tactical Gear II Mod together with this one but it is not required.\n\n[b]Important[/b]\n[list]\n[*]Restart the game after activating the mod\n[*]It is save game compatible but you won't have spare mags for existing weapons\n[*]Weapons from mods won't have mags. There could also be problems with custom calibers\n[*]If you are a mod creator and want to increase compatibility, please contact me\n[*]There was decent amount of playtesting but there can still be bugs.\n[*]If you find bugs, please send me your bug reports.\n[/list]",
 	'image', "Mod/URkxyfE/Images/JA3Revised-Mags.png",
-	'last_changes', "Test steam upload",
+	'last_changes', "Hotfix Gold Fever and The Lion's Roar 0/0 ammo issue",
 	'id', "URkxyfE",
 	'author', "permanent666",
-	'version_minor', 11,
-	'version', 137,
+	'version_minor', 12,
+	'version', 139,
 	'lua_revision', 233360,
 	'saved_with_revision', 350233,
 	'code', {
@@ -83,8 +83,8 @@ return PlaceObj('ModDef', {
 		RevisedMagDropChance = "10",
 	},
 	'has_data', true,
-	'saved', 1712951744,
-	'code_hash', 7631603858181360894,
+	'saved', 1717321300,
+	'code_hash', 3218958919416122767,
 	'affected_resources', {
 		PlaceObj('ModResourcePreset', {
 			'Class', "WeaponComponent",


### PR DESCRIPTION
 - Disabled `REV_SetupWeapon` for `LionRoar` and `GoldenGun` as it was causing them to have 0/0 ammo capacity.
 - Moved `REV_SetupWeapon` to `ClassesPreprocess` to work well with Rato's GBO `ClassesGenerate` processing.