### PR TITLE
Allow to run Revised Tactical Gear II without Revised Mags II

### DIFF
--- a/Code/SETUP_MagsItemDefinition.lua
+++ b/Code/SETUP_MagsItemDefinition.lua
@@ -236,3 +236,56 @@ function OnMsg.DataLoaded()
 
 	ammoTab.item_classes[#ammoTab.item_classes + 1] = "Mag"
 end
+
+function OnMsg.RevisedWeightAddedToItemProperties()
+	LargeMag.Weight = 300
+	-- G36MagazineLarger
+	-- FNMinimiMagazineLarge
+	-- HKG3MagazineLarger
+	-- FNMinimiMagazineLarger
+	-- AK47MagazineMagLarger
+	-- AA12MagazineLarge
+
+	PistolMag.Weight = 100
+	-- BerettaMagazineLarge
+	-- DesertEagleMagazine
+	-- GlockMagazineLarge
+	-- GlockMagazine
+	-- DesertEagleMagazineLarge
+	-- BHPMagazine
+	-- BHPMagazineLarge
+	-- BerettaMagazine
+
+	RifleMag.Weight = 200
+	-- G36MagazineQuick
+	-- STANAGMagazineLarge
+	-- AK47MagazineMagLarge
+	-- FNFALMagazine
+	-- GalilMagazineLarge
+	-- HKG3Magazine
+	-- AA12Magazine
+	-- M14MagazineLarge
+	-- AUGMagazineLarge
+	-- M14Magazine
+	-- SVDMagazine
+	-- GalilMagazine
+	-- STANAGMagazine
+	-- FAMASMagazine
+	-- BarretM82Magazine
+	-- AK47Magazine
+	-- AK74MagazineLarge
+	-- BarretM82MagazineLarge
+	-- HKG3MagazineLarge
+	-- FNFALMagazineLarge
+	-- AUGMagazine
+	-- G36MagazineLarge
+	-- AK74Magazine
+
+	SmgMag.Weight = 150
+	-- MP40MagazineLarge
+	-- UZIMagazine
+	-- MP5Magazine
+	-- MP40Magazine
+	-- MP5MagazineLarge
+	-- UZIMagazineLarge
+end

--- a/items.lua
+++ b/items.lua
@@ -60,6 +60,7 @@ return {
 			'Help', "How often the mags will drop",
 			'DefaultValue', "10",
 			'ChoiceList', {
+				"0",
 				"1",
 				"5",
 				"10",

--- a/metadata.lua
+++ b/metadata.lua
@@ -2,11 +2,11 @@ return PlaceObj('ModDef', {
 	'title', "Revised Mags II",
 	'description', "This is a reworked rerelease of Ablomis' Revised Mags mod. \n\nThis mod adds magazines for weapons to the game. \n\nIt is recommended that you use the Revised Tactical Gear II Mod together with this one but it is not required.\n\n[b]Important[/b]\n[list]\n[*]Restart the game after activating the mod\n[*]It is save game compatible but you won't have spare mags for existing weapons\n[*]Weapons from mods won't have mags. There could also be problems with custom calibers\n[*]If you are a mod creator and want to increase compatibility, please contact me\n[*]There was decent amount of playtesting but there can still be bugs.\n[*]If you find bugs, please send me your bug reports.\n[/list]",
 	'image', "Mod/URkxyfE/Images/JA3Revised-Mags.png",
-	'last_changes', "Reduced shop prices for mags",
+	'last_changes', "Allow to run Revised Tactical Gear II without Revised Mags II",
 	'id', "URkxyfE",
 	'author', "permanent666",
-	'version_minor', 13,
-	'version', 147,
+	'version_minor', 14,
+	'version', 148,
 	'lua_revision', 233360,
 	'saved_with_revision', 350233,
 	'code', {
@@ -83,8 +83,8 @@ return PlaceObj('ModDef', {
 		RevisedMagDropChance = "10",
 	},
 	'has_data', true,
-	'saved', 1721947423,
-	'code_hash', 6108061411011978350,
+	'saved', 1723649921,
+	'code_hash', -1417196752588261458,
 	'affected_resources', {
 		PlaceObj('ModResourcePreset', {
 			'Class', "WeaponComponent",


### PR DESCRIPTION
- Moved `Weight` setup of Mags from `ja3-revised-gear`
- Added option `0` to `Mag Drop Chance`